### PR TITLE
Fix upload flow OCR metadata and lab parsing UI

### DIFF
--- a/records/templates/main/upload.html
+++ b/records/templates/main/upload.html
@@ -51,6 +51,7 @@
 
   <div class="rounded-2xl p-8" style="background:#FFFFF5;box-shadow:0 10px 14px rgba(10,30,74,.10),inset 0 0 0 1px rgba(10,30,74,.08)">
     <div id="errorBox" class="hidden mb-4 rounded-2xl p-4 bg-white border border-danger text-danger"></div>
+    <div id="statusBox" class="hidden mb-4 rounded-2xl p-4 bg-white border border-success text-success"></div>
 
     <div class="grid grid-cols-1 lg:grid-cols-2 gap-6">
       <div>
@@ -78,6 +79,8 @@
           </div>
           <textarea id="workText" class="w-full h-72 rounded-xl px-4 py-3 border border-gray-300 bg-white" placeholder="{% trans 'Тук ще се визуализира OCR или Анализ в зависимост от етапа.' %}" disabled></textarea>
         </div>
+
+        <div id="summaryBox" class="hidden mb-4 rounded-2xl border border-primary/30 bg-white px-4 py-3 text-sm text-primaryDark"></div>
 
         <div id="labWrap" class="hidden">
           <div class="text-sm text-primaryDark font-semibold mb-2">


### PR DESCRIPTION
## Summary
- return OCR engine metadata and timing from the upload API so the UI can surface which OCR service handled the file
- normalise OCR text, fix % recognition, and render lab results, analysis summary, and success feedback in the upload workflow
- add status and summary containers to the upload page for the improved frontend behaviour

## Testing
- python -m compileall records/views/upload.py

------
https://chatgpt.com/codex/tasks/task_e_68cbc52e2dd883269c68196d9543b0da