### PR TITLE
Improve upload workflow step display and persistence

### DIFF
--- a/records/templates/main/upload.html
+++ b/records/templates/main/upload.html
@@ -51,6 +51,7 @@
 
   <div class="rounded-2xl p-8" style="background:#FFFFF5;box-shadow:0 10px 14px rgba(10,30,74,.10),inset 0 0 0 1px rgba(10,30,74,.08)">
     <div id="errorBox" class="hidden mb-4 rounded-2xl p-4 bg-white border border-danger text-danger"></div>
+    <div id="statusBox" class="hidden mb-4 rounded-2xl p-4 bg-white border border-success text-success"></div>
 
     <div class="grid grid-cols-1 lg:grid-cols-2 gap-6">
       <div>
@@ -73,11 +74,13 @@
       <div>
         <div class="mb-3">
           <div class="text-sm text-primaryDark font-semibold mb-2">
-            <span id="workLabel">{% trans "OCR Текст" %}</span>
-            <span id="workMeta" class="ml-2 inline-flex items-center px-2 py-0.5 rounded border border-primary text-xs text-primaryDark" aria-live="polite"></span>
+            <span id="workLabel">{% trans "Стъпка 1: Екстракт на текст" %}</span>
+            <span id="workMeta" class="ml-2 inline-flex items-center px-2 py-0.5 rounded border border-primary text-xs text-primaryDark hidden" aria-live="polite"></span>
           </div>
           <textarea id="workText" class="w-full h-72 rounded-xl px-4 py-3 border border-gray-300 bg-white" placeholder="{% trans 'Тук ще се визуализира OCR или Анализ в зависимост от етапа.' %}" disabled></textarea>
         </div>
+
+        <div id="summaryBox" class="hidden mb-4 rounded-2xl border border-primary/30 bg-white px-4 py-3 text-sm text-primaryDark"></div>
 
         <div id="labWrap" class="hidden">
           <div class="text-sm text-primaryDark font-semibold mb-2">

--- a/records/views/upload.py
+++ b/records/views/upload.py
@@ -7,9 +7,27 @@ from records.models import (
     MedicalSpecialty,
     MedicalCategory,
     MedicalEvent,
+    Document,
+    PatientProfile,
 )
-import os, requests, json, re
+import os, requests, json, re, time, hashlib
 from datetime import datetime
+from django.utils import timezone
+
+
+def _parse_date(value):
+    s = (value or "").strip()
+    if not s:
+        return None
+    for fmt in ("%Y-%m-%d", "%d.%m.%Y", "%d/%m/%Y", "%Y/%m/%d"):
+        try:
+            return datetime.strptime(s, fmt).date()
+        except Exception:
+            continue
+    try:
+        return datetime.fromisoformat(s).date()
+    except Exception:
+        return None
 
 def _safe_name(o):
     n = ""
@@ -50,21 +68,47 @@ def _call_flask_ocr(dj_file, ctx):
     dj_file.seek(0)
     files = {"file": (dj_file.name, dj_file.read(), dj_file.content_type or "application/octet-stream")}
     data = {
-        "event_type": ctx.get("event_type",""),
-        "category_name": ctx.get("category_name",""),
-        "specialty_name": ctx.get("specialty_name","")
+        "event_type": ctx.get("event_type", ""),
+        "category_name": ctx.get("category_name", ""),
+        "specialty_name": ctx.get("specialty_name", ""),
     }
+    started = time.monotonic()
+    base_meta = {"engine": "OCR Service"}
     try:
         r = requests.post(url, files=files, data=data, timeout=timeout)
+        elapsed = int(max((time.monotonic() - started) * 1000, 0))
+        meta = {**base_meta, "duration_ms": elapsed}
         if r.status_code != 200:
-            return ""
-        if "application/json" in r.headers.get("content-type",""):
+            meta["status_code"] = r.status_code
+            return "", meta
+        if "application/json" in r.headers.get("content-type", ""):
             p = r.json()
             if isinstance(p, dict):
-                return (p.get("ocr_text") or p.get("text") or p.get("full_text") or p.get("data",{}).get("raw_text","") or "").strip()
-        return (r.text or "").strip()
+                text = (
+                    p.get("ocr_text")
+                    or p.get("text")
+                    or p.get("full_text")
+                    or p.get("data", {}).get("raw_text", "")
+                    or ""
+                ).strip()
+                resp_meta = p.get("meta") if isinstance(p.get("meta"), dict) else {}
+                if resp_meta:
+                    for k, v in resp_meta.items():
+                        if v is None:
+                            continue
+                        meta.setdefault(k, v)
+                if not meta.get("engine"):
+                    meta["engine"] = (
+                        resp_meta.get("engine")
+                        if isinstance(resp_meta, dict)
+                        else None
+                    ) or p.get("engine") or p.get("provider") or base_meta["engine"]
+                return text, meta
+        text = (r.text or "").strip()
+        return text, meta
     except Exception:
-        return ""
+        base_meta["error"] = "request_failed"
+        return "", base_meta
 
 def _vision_available():
     try:
@@ -79,28 +123,31 @@ def _call_vision_ocr_bytes(blob):
     try:
         from google.cloud import vision
     except Exception:
-        return ""
+        return "", {"engine": "Google Cloud Vision", "error": "unavailable"}
     try:
         client = vision.ImageAnnotatorClient()
         image = vision.Image(content=blob)
+        started = time.monotonic()
         resp = client.document_text_detection(image=image)
+        elapsed = int(max((time.monotonic() - started) * 1000, 0))
+        meta = {"engine": "Google Cloud Vision", "duration_ms": elapsed}
         if getattr(resp, "full_text_annotation", None) and getattr(resp.full_text_annotation, "text", ""):
-            return resp.full_text_annotation.text.strip()
+            return resp.full_text_annotation.text.strip(), meta
         arr = getattr(resp, "text_annotations", None)
         if arr and len(arr) > 0 and getattr(arr[0], "description", ""):
-            return arr[0].description.strip()
-        return ""
+            return arr[0].description.strip(), meta
+        return "", meta
     except Exception:
-        return ""
+        return "", {"engine": "Google Cloud Vision", "error": "failed"}
 
 def _ocr_pipeline(dj_file, ctx):
     dj_file.seek(0)
     vb = dj_file.read()
-    vision_txt = ""
+    vision_txt, vision_meta = "", {}
     if _vision_available():
-        vision_txt = _call_vision_ocr_bytes(vb)
+        vision_txt, vision_meta = _call_vision_ocr_bytes(vb)
     if vision_txt:
-        return vision_txt
+        return vision_txt, vision_meta
     dj_file.seek(0)
     return _call_flask_ocr(dj_file, ctx)
 
@@ -160,10 +207,35 @@ def upload_ocr(request):
     cat_name = _id_to_name(MedicalCategory, cat_id)
     ctx = {"event_type": doc_name, "specialty_name": spec_name, "category_name": cat_name}
     merged = ""
+    meta_list = []
     for f in files:
-        txt = _ocr_pipeline(f, ctx)
+        txt, meta = _ocr_pipeline(f, ctx)
         merged = _merge_lines(merged, txt)
-    return JsonResponse({"ocr_text": merged})
+        if meta:
+            meta_list.append(meta)
+
+    resp = {"ocr_text": merged}
+    if meta_list:
+        if len(meta_list) == 1:
+            resp["meta"] = meta_list[0]
+        else:
+            engines = []
+            total = 0
+            for m in meta_list:
+                eng = m.get("engine") if isinstance(m, dict) else ""
+                if eng and eng not in engines:
+                    engines.append(eng)
+                dur = m.get("duration_ms") if isinstance(m, dict) else None
+                if isinstance(dur, (int, float)):
+                    total += int(dur)
+            meta_combined = {}
+            if engines:
+                meta_combined["engine"] = ", ".join(engines)
+            if total:
+                meta_combined["duration_ms"] = total
+            if meta_combined:
+                resp["meta"] = meta_combined
+    return JsonResponse(resp)
 
 @login_required
 @require_http_methods(["POST"])
@@ -184,6 +256,7 @@ def upload_analyze(request):
     clean = _anonymize(txt)
     api_key = os.getenv("OPENAI_API_KEY", "").strip()
     model = os.getenv("OPENAI_MODEL", "gpt-4o-mini")
+    started = time.monotonic()
     if api_key:
         try:
             from openai import OpenAI
@@ -198,17 +271,178 @@ def upload_analyze(request):
             content = resp.choices[0].message.content or "{}"
             data = json.loads(content)
             summary = (data.get("summary") or "").strip()
-            return JsonResponse({"summary": summary, "data": data})
+            elapsed = int(max((time.monotonic() - started) * 1000, 0))
+            meta = {
+                "engine": f"OpenAI {model}",
+                "provider": "openai",
+                "duration_ms": elapsed,
+            }
+            return JsonResponse({"summary": summary, "data": data, "meta": meta})
         except Exception:
             pass
     data = _fallback_extract(clean, specialty_name)
     summary = data.get("summary","")
-    return JsonResponse({"summary": summary, "data": data})
+    elapsed = int(max((time.monotonic() - started) * 1000, 0))
+    meta = {
+        "engine": "Правила (fallback)",
+        "provider": "fallback",
+        "duration_ms": elapsed,
+    }
+    return JsonResponse({"summary": summary, "data": data, "meta": meta})
 
 @login_required
 @require_http_methods(["POST"])
 def upload_confirm(request):
-    return JsonResponse({"ok": True})
+    upload_file = request.FILES.get("file")
+    if not upload_file:
+        return HttpResponseBadRequest("Missing file")
+
+    def _obj_or_400(model, key):
+        value = request.POST.get(key) or request.POST.get(key.replace("_id", ""), "")
+        if not value or not str(value).isdigit():
+            return None
+        return model.objects.filter(id=int(value)).first()
+
+    category = _obj_or_400(MedicalCategory, "category_id")
+    specialty = _obj_or_400(MedicalSpecialty, "specialty_id")
+    doc_type = _obj_or_400(DocumentType, "doc_type_id")
+    if not (category and specialty and doc_type):
+        return HttpResponseBadRequest("Missing classification")
+
+    file_kind = (request.POST.get("file_kind") or "").strip().lower()
+    valid_kinds = {"image", "pdf", "other"}
+
+    def _guess_file_kind(f):
+        name = (getattr(f, "name", "") or "").lower()
+        if name.endswith((".png", ".jpg", ".jpeg", ".gif", ".bmp", ".tif", ".tiff", ".webp")):
+            return "image"
+        if name.endswith(".pdf"):
+            return "pdf"
+        mime = (getattr(f, "content_type", "") or "").lower()
+        if mime.startswith("image/"):
+            return "image"
+        if mime == "application/pdf":
+            return "pdf"
+        return "other"
+
+    if file_kind not in valid_kinds:
+        file_kind = _guess_file_kind(upload_file)
+
+    event = None
+    event_id = request.POST.get("event_id") or ""
+    if event_id and str(event_id).isdigit():
+        event = MedicalEvent.objects.filter(id=int(event_id), owner=request.user).first()
+
+    ocr_text = request.POST.get("ocr_text") or ""
+    ocr_meta_raw = request.POST.get("ocr_meta") or ""
+    analysis_raw = request.POST.get("analysis") or ""
+    analysis_meta_raw = request.POST.get("analysis_meta") or ""
+    summary = (request.POST.get("summary") or "").strip()
+    document_date = _parse_date(request.POST.get("document_date"))
+
+    def _json_load(raw):
+        if not raw:
+            return {}
+        try:
+            return json.loads(raw)
+        except Exception:
+            return {}
+
+    ocr_meta = _json_load(ocr_meta_raw)
+    if not isinstance(ocr_meta, dict):
+        ocr_meta = {}
+    analysis_payload = _json_load(analysis_raw)
+    if not isinstance(analysis_payload, dict):
+        analysis_payload = {}
+    analysis_meta = _json_load(analysis_meta_raw)
+    if not isinstance(analysis_meta, dict):
+        analysis_meta = {}
+    if analysis_meta:
+        analysis_payload.setdefault("meta", analysis_meta)
+
+    event_date = (
+        _parse_date(request.POST.get("event_date"))
+        or _parse_date(analysis_payload.get("event_date"))
+        or _parse_date((analysis_payload.get("data") or {}).get("event_date"))
+        or timezone.now().date()
+    )
+
+    if not document_date and event_date:
+        document_date = event_date
+
+    patient, _ = PatientProfile.objects.get_or_create(user=request.user)
+
+    if not event:
+        event_summary = summary[:255] if summary else (_safe_name(doc_type) or "Документ")
+        event = MedicalEvent.objects.create(
+            patient=patient,
+            owner=request.user,
+            specialty=specialty,
+            category=category,
+            doc_type=doc_type,
+            event_date=event_date,
+            summary=event_summary,
+        )
+
+    hasher = hashlib.sha256()
+    try:
+        for chunk in upload_file.chunks():
+            hasher.update(chunk)
+    except Exception:
+        data = upload_file.read()
+        hasher.update(data)
+    digest = hasher.hexdigest()
+    try:
+        upload_file.seek(0)
+    except Exception:
+        pass
+
+    doc = Document(
+        owner=request.user,
+        medical_event=event,
+        specialty=specialty,
+        category=category,
+        doc_type=doc_type,
+        document_date=document_date,
+        date_created=timezone.now().date(),
+        doc_kind=file_kind or _guess_file_kind(upload_file),
+        file_size=getattr(upload_file, "size", None) or None,
+        file_mime=getattr(upload_file, "content_type", None) or None,
+        original_ocr_text=ocr_text,
+        summary=summary or str(analysis_payload.get("summary") or ""),
+        notes=json.dumps(
+            {
+                "analysis": analysis_payload,
+                "ocr_meta": ocr_meta,
+            },
+            ensure_ascii=False,
+        ),
+        sha256=digest,
+    )
+    doc.file.save(upload_file.name, upload_file, save=False)
+    doc.save()
+
+    detail_bits = [f"Документ №{doc.id}"]
+    if event:
+        detail_bits.append(f"Събитие №{event.id}")
+
+    meta = {
+        "engine": "MedJ Upload",
+        "detail": " • ".join(detail_bits),
+        "document_id": doc.id,
+    }
+    if event:
+        meta["event_id"] = event.id
+
+    return JsonResponse(
+        {
+            "ok": True,
+            "document_id": doc.id,
+            "event_id": event.id if event else None,
+            "meta": meta,
+            "file_url": doc.file.url if doc.file else "",
+        }
+    )
 
 @login_required
 @require_http_methods(["GET"])
@@ -223,7 +457,12 @@ def upload_preview(request):
 @login_required
 @require_http_methods(["GET"])
 def upload_history(request):
-    return render(request, "main/upload_history.html", {})
+    documents = (
+        Document.objects.filter(owner=request.user)
+        .select_related("medical_event", "doc_type")
+        .order_by("-uploaded_at")
+    )
+    return render(request, "main/history.html", {"documents": documents})
 
 @login_required
 @require_http_methods(["GET"])

--- a/theme/static/js/upload_logic.js
+++ b/theme/static/js/upload_logic.js
@@ -18,6 +18,13 @@ const dis = (x, f) => {
   x.classList.toggle("opacity-50", !!f);
   x.classList.toggle("cursor-not-allowed", !!f);
 };
+const clearStatus = () => {
+  const box = $("statusBox");
+  if (box) {
+    box.textContent = "";
+    hide(box);
+  }
+};
 const getCSRF = () => {
   const t = document.querySelector('input[name="csrfmiddlewaretoken"]');
   if (t && t.value) return t.value;
@@ -31,11 +38,19 @@ let FILE_KIND = "";
 let FILE_URL = null;
 let OCR_TEXT_ORIG = "";
 let OCR_META = {};
-let ANALYSIS = { summary: "", data: { tables: [], blood_test_results: [], suggested_tags: [] } };
+let ANALYSIS = { summary: "", data: { tables: [], blood_test_results: [], suggested_tags: [] }, meta: {} };
 let ANALYZED_READY = false;
 let CLASS_LOCK = false;
 let DOC_LOCK = false;
 let FILE_KIND_LOCK = false;
+
+const STEP_CONFIG = {
+  1: { label: "Стъпка 1: Екстракт на текст" },
+  2: { label: "Стъпка 2: Анализ" },
+  3: { label: "Стъпка 3: Запазване" },
+};
+let CURRENT_STEP = 1;
+const STEP_META = { 1: null, 2: null, 3: null };
 
 function ensureStyles() {
   if ($("uxUploadInject")) return;
@@ -94,23 +109,72 @@ function updateButtons() {
   bCfm ? (ANALYZED_READY && requiredTagsReady() ? show(bCfm) : hide(bCfm)) : null;
 }
 
-function stepMetaNode() {
-  let n = document.querySelector('label[for="workText"]');
-  if (!n) n = $("workMeta");
-  if (!n) {
-    const ta = $("workText");
-    if (ta?.parentElement) {
-      n = document.createElement("div");
-      n.id = "workMeta";
-      n.className = "text-xs text-gray-600 mb-1";
-      ta.parentElement.insertBefore(n, ta);
+function normalizeStepMeta(meta) {
+  if (!meta || typeof meta !== "object") return {};
+  const engine = meta.engine || meta.ocr_engine || meta.provider || meta.name || meta.used || "";
+  const duration = meta.duration_ms ?? meta.duration ?? meta.time_ms ?? meta.dt_ms ?? meta.elapsed_ms;
+  const detail = meta.detail || meta.note || meta.status || meta.message || "";
+  const info = {};
+  if (engine) info.engine = String(engine);
+  if (duration != null && !Number.isNaN(Number(duration))) {
+    info.duration_ms = Number(duration);
+  }
+  if (detail) info.detail = String(detail);
+  if (meta.document_id != null) info.document_id = meta.document_id;
+  if (meta.event_id != null) info.event_id = meta.event_id;
+  return info;
+}
+
+function updateStepDisplay() {
+  const labelNode = $("workLabel");
+  const metaNode = $("workMeta");
+  const info = STEP_CONFIG[CURRENT_STEP] || STEP_CONFIG[1];
+  const meta = STEP_META[CURRENT_STEP] || {};
+  const baseLabel = info?.label || "";
+  const text = meta.engine ? `${baseLabel} : ${meta.engine}` : baseLabel;
+  if (labelNode) labelNode.textContent = text;
+  if (metaNode) {
+    const parts = [];
+    if (meta.duration_ms != null && !Number.isNaN(meta.duration_ms)) {
+      parts.push(`${meta.duration_ms} ms`);
+    }
+    if (meta.detail) parts.push(meta.detail);
+    if (!parts.length) {
+      metaNode.textContent = "";
+      metaNode.classList?.add("hidden");
+    } else {
+      metaNode.textContent = parts.join(" • ");
+      metaNode.classList?.remove("hidden");
     }
   }
-  return n;
 }
-function setStepLabel(text) {
-  const n = stepMetaNode();
-  if (n) n.textContent = text || "";
+
+function applyStepMeta(step, meta, makeCurrent = false) {
+  const idx = Number(step);
+  if (![1, 2, 3].includes(idx)) return;
+  if (meta) {
+    STEP_META[idx] = normalizeStepMeta(meta);
+  }
+  if (makeCurrent) {
+    CURRENT_STEP = idx;
+  }
+  if (makeCurrent || idx === CURRENT_STEP) {
+    updateStepDisplay();
+  }
+}
+
+function setCurrentStep(step) {
+  const idx = Number(step);
+  CURRENT_STEP = [1, 2, 3].includes(idx) ? idx : 1;
+  updateStepDisplay();
+}
+
+function resetSteps() {
+  STEP_META[1] = null;
+  STEP_META[2] = null;
+  STEP_META[3] = null;
+  CURRENT_STEP = 1;
+  updateStepDisplay();
 }
 
 function setBusy(on) {
@@ -118,6 +182,7 @@ function setBusy(on) {
   if (o) (on ? show(o) : hide(o));
 }
 function showError(msg) {
+  clearStatus();
   const box = $("errorBox");
   if (box) {
     box.textContent = msg || "Грешка.";
@@ -129,6 +194,18 @@ function clearError() {
   if (box) {
     box.textContent = "";
     hide(box);
+  }
+}
+
+function showStatus(msg) {
+  const box = $("statusBox");
+  if (box) {
+    if (msg) {
+      box.textContent = msg;
+      show(box);
+    } else {
+      clearStatus();
+    }
   }
 }
 
@@ -178,7 +255,21 @@ function handleFileInputChange() {
   FILE_KIND_LOCK = true;
   dis(kind, true);
   ANALYZED_READY = false;
+  OCR_TEXT_ORIG = "";
+  OCR_META = {};
+  ANALYSIS = { summary: "", data: { tables: [], blood_test_results: [], suggested_tags: [] }, meta: {} };
+  setWorkText("");
+  renderLabTable([]);
+  renderSummary("");
+  clearStatus();
+  clearError();
+  resetSteps();
   renderPreview();
+  const btnConfirm = $("btnConfirm");
+  if (btnConfirm) {
+    btnConfirm.removeAttribute("aria-disabled");
+    dis(btnConfirm, false);
+  }
   lockDocType();
   updateDropdownFlow();
   updateButtons();
@@ -249,6 +340,8 @@ function cleanOCRText(text) {
   s = s.replace(/[‐‒–—−]/g, "-");
   // If we see "... -96 1.93", that should be "... % 1.93"
   s = s.replace(/-\s*96(?=\s*\d)/g, " %");
+  // Also handle "...-96" directly following a word
+  s = s.replace(/([\p{L}])\s*-\s*96\b/gu, "$1 %");
   // If we see "... -% 54.10", fix spacing
   s = s.replace(/-\s*%(?=\s*\d)/g, " %");
   // Vertical bars from tables
@@ -302,9 +395,15 @@ function normalizeRows(rows) {
 
 function renderLabTable(items) {
   const wrap = $("labWrap");
-  const slot = $("labTable");
+  const slot = $("labTableSlot");
   if (!wrap || !slot) return;
-  const rows = (items || []).map((x, i) => {
+  const list = Array.isArray(items) ? items : [];
+  if (!list.length) {
+    seth(slot, "");
+    hide(wrap);
+    return;
+  }
+  const rows = list.map((x, i) => {
     const n = x.name || "";
     const v = x.value != null ? String(x.value) : "";
     const u = x.unit || "";
@@ -319,19 +418,19 @@ function renderLabTable(items) {
 
 function renderSummary(text) {
   const box = $("summaryBox");
-  if (box) { box.textContent = text || ""; show(box); }
+  if (!box) return;
+  const value = (text || "").toString().trim();
+  if (!value) {
+    box.textContent = "";
+    hide(box);
+    return;
+  }
+  box.textContent = value;
+  show(box);
 }
 
 function renderOCRMeta(meta) {
-  const n = stepMetaNode();
-  let s = "";
-  if (meta && typeof meta === "object") {
-    const eng = meta.engine || meta.ocr_engine || meta.provider || meta.name || meta.used || "";
-    const dur = meta.duration_ms || meta.dt_ms || meta.time_ms || meta.elapsed_ms || meta.duration || "";
-    s = eng ? `OCR: ${eng}` : "";
-    if (dur) s = s ? `${s} • ${dur} ms` : `${dur} ms`;
-  }
-  if (n) n.textContent = s;
+  applyStepMeta(1, meta, CURRENT_STEP === 1);
 }
 
 function getWorkText() { return $("workText")?.value || ""; }
@@ -339,8 +438,12 @@ function setWorkText(t) { const ta = $("workText"); if (ta) ta.value = t || ""; 
 
 async function doOCR() {
   clearError();
+  clearStatus();
   const p = picks();
   if (!p.file || !pipelineReady()) { showError("Липсват задължителни полета."); return; }
+  STEP_META[2] = null;
+  STEP_META[3] = null;
+  setCurrentStep(1);
   const fd = new FormData();
   fd.append("file", p.file);
   fd.append("file_kind", p.fileKind);
@@ -356,13 +459,15 @@ async function doOCR() {
     const text = data?.text || data?.ocr_text || "";
     const meta = data?.meta || data?.ocr_meta || {};
     OCR_META = meta || {};
-    renderOCRMeta(OCR_META);
-    OCR_TEXT_ORIG = text || "";
-    setWorkText(OCR_TEXT_ORIG);
+    applyStepMeta(1, OCR_META, true);
+    const cleaned = cleanOCRText(text);
+    OCR_TEXT_ORIG = cleaned;
+    setWorkText(cleaned);
     ANALYZED_READY = false;
+    renderSummary("");
     updateButtons();
     const labs = parseLabs(OCR_TEXT_ORIG);
-    if (labs.length) renderLabTable(labs);
+    renderLabTable(labs);
   } catch {
     showError("OCR неуспешен.");
   } finally { setBusy(false); }
@@ -385,7 +490,8 @@ async function doAnalyze() {
     if (!res.ok) throw new Error("analyze_failed");
     let data = {};
     try { data = await res.json(); } catch {}
-    ANALYSIS = data || {};
+    const meta = data?.meta || {};
+    ANALYSIS = { ...(data || {}), meta };
     const summary = (ANALYSIS.summary || ANALYSIS.result?.summary || ANALYSIS.data?.summary || ANALYSIS.summary_text || "").toString();
     renderSummary(summary);
     const rows = normalizeRows(
@@ -394,8 +500,9 @@ async function doAnalyze() {
       ANALYSIS.data?.blood_test_results ||
       []
     );
-    if (rows.length) renderLabTable(rows);
+    renderLabTable(rows);
     ANALYZED_READY = true;
+    applyStepMeta(2, meta, true);
     updateButtons();
   } catch {
     showError("Анализът неуспешен.");
@@ -404,27 +511,54 @@ async function doAnalyze() {
 
 async function doConfirm() {
   clearError();
+  clearStatus();
   const text = getWorkText();
   const p = picksPayload();
+  const raw = picks();
   if (!ANALYZED_READY || !requiredTagsReady()) { showError("Анализът не е завършен."); return; }
+  if (!raw.file) { showError("Липсва файл за запис."); return; }
   setBusy(true);
   try {
-    const payload = { text, ...p, analysis: ANALYSIS || {} };
+    const fd = new FormData();
+    fd.append("file", raw.file);
+    fd.append("file_kind", raw.fileKind || FILE_KIND || "");
+    fd.append("category_id", p.category_id || "");
+    fd.append("specialty_id", p.specialty_id || "");
+    fd.append("doc_type_id", p.doc_type_id || "");
+    fd.append("ocr_text", OCR_TEXT_ORIG || text || "");
+    fd.append("text", text || "");
+    if (p.event_id) fd.append("event_id", p.event_id);
+    const summary = (ANALYSIS.summary || ANALYSIS.result?.summary || ANALYSIS.data?.summary || ANALYSIS.summary_text || "").toString();
+    if (summary) fd.append("summary", summary);
+    const eventDate = ANALYSIS.data?.event_date || ANALYSIS.event_date || "";
+    if (eventDate) {
+      fd.append("event_date", eventDate);
+      fd.append("document_date", eventDate);
+    }
+    if (OCR_META && Object.keys(OCR_META).length) fd.append("ocr_meta", JSON.stringify(OCR_META));
+    if (ANALYSIS && Object.keys(ANALYSIS).length) fd.append("analysis", JSON.stringify(ANALYSIS));
+    if (ANALYSIS?.meta && Object.keys(ANALYSIS.meta || {}).length) {
+      fd.append("analysis_meta", JSON.stringify(ANALYSIS.meta));
+    }
     const res = await fetch(API.confirm, {
       method: "POST",
       credentials: "same-origin",
-      headers: { "Content-Type": "application/json", "X-CSRFToken": getCSRF() },
-      body: JSON.stringify(payload),
+      headers: { "X-CSRFToken": getCSRF() },
+      body: fd,
     });
     if (!res.ok) throw new Error("confirm_failed");
     let ok = res.ok;
-    try {
-      const j = await res.json();
-      ok = ok || !!(j && (j.ok || j.success || j.saved || j.id));
-    } catch {} // 204 No Content fallback
+    let data = {};
+    try { data = await res.json(); } catch {}
+    const meta = data?.meta || {};
+    if (res.ok && (data?.ok || data?.success || data?.saved || data?.id || data?.document_id)) {
+      ok = true;
+    }
     if (ok) {
       const btn = $("btnConfirm");
       if (btn) { btn.setAttribute("aria-disabled","true"); dis(btn, true); }
+      showStatus("Документът е записан успешно.");
+      applyStepMeta(3, { ...meta, document_id: data?.document_id, event_id: data?.event_id }, true);
     }
   } catch {
     showError("Записът е неуспешен.");
@@ -458,50 +592,22 @@ function bindEvents() {
   btnConfirm && btnConfirm.addEventListener("click", doConfirm);
 
   const ta = $("workText");
-  ta && ta.addEventListener("input", () => { ANALYZED_READY = false; updateButtons(); });
-}
-
-function updateDropdownFlow() {
-  const p = picks();
-  const cat = $("sel_category");
-  const spc = $("sel_specialty");
-  const doc = $("sel_doc_type");
-  const kind = $("file_kind");
-  const file = $("file_input");
-  const choose = $("chooseFileBtn");
-
-  if (CLASS_LOCK) {
-    dis(cat, true); dis(spc, true); dis(doc, true); dis(kind, true); dis(file, false);
-    if (choose) { choose.setAttribute("aria-disabled","true"); choose.classList.remove("btn-armed"); }
-    updateButtons(); return;
-  }
-
-  const readySpc = !!p.category;
-  const readyDoc = readySpc && !!p.specialty;
-  const readyKind = readyDoc && !!p.docType;
-  const readyFile = readyKind && !!p.fileKind;
-
-  dis(cat, false);
-  dis(spc, !readySpc); if (!readySpc) setv(spc, "");
-  dis(doc, !readyDoc || DOC_LOCK); if (!readyDoc && !DOC_LOCK) setv(doc, "");
-  if (FILE_KIND_LOCK) dis(kind, true);
-  else {
-    dis(kind, !readyKind);
-    if (!readyKind) { setv(kind, ""); FILE_KIND = ""; }
-  }
-  dis(file, !readyFile);
-
-  if (choose) {
-    if (readyFile) { choose.removeAttribute("aria-disabled"); choose.classList.add("btn-armed"); }
-    else { choose.setAttribute("aria-disabled","true"); choose.classList.remove("btn-armed"); }
-  }
-  updateButtons();
+  ta && ta.addEventListener("input", () => {
+    ANALYZED_READY = false;
+    STEP_META[2] = null;
+    STEP_META[3] = null;
+    setCurrentStep(1);
+    const btn = $("btnConfirm");
+    if (btn) { btn.removeAttribute("aria-disabled"); dis(btn, false); }
+    updateButtons();
+  });
 }
 
 function init() {
   bindEvents();
   updateDropdownFlow();
   updateButtons();
+  resetSteps();
   renderOCRMeta(OCR_META || {});
 }
 


### PR DESCRIPTION
## Summary
- show explicit stage labels with OCR/analyse/save metadata and reset handling throughout the upload flow
- persist confirmed uploads by creating document records (with related events and metadata) and reuse the existing history template to display saved files
- return analysis engine details from the backend and post the full payload (file, OCR text, analysis) from the UI when saving

## Testing
- python -m compileall records/views/upload.py

------
https://chatgpt.com/codex/tasks/task_e_68cbc52e2dd883269c68196d9543b0da