### PR TITLE
Enhance share filters and exports

### DIFF
--- a/docker/web/Dockerfile
+++ b/docker/web/Dockerfile
@@ -7,7 +7,10 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
 WORKDIR /app
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    build-essential curl libpq-dev gettext git \
+    build-essential curl git gettext libpq-dev \
+    libcairo2 libffi-dev libgdk-pixbuf-2.0-0 \
+    libpangocairo-1.0-0 libpangoft2-1.0-0 libharfbuzz0b libfribidi0 \
+    shared-mime-info fonts-dejavu-core \
  && rm -rf /var/lib/apt/lists/*
 
 COPY requirements.txt /app/requirements.txt

--- a/records/templates/main/share.html
+++ b/records/templates/main/share.html
@@ -31,13 +31,67 @@
           <input type="number" min="1" max="8760" name="hours_csv" value="24" class="w-full rounded-lg p-2 border border-gray-300 bg-white text-[#0A4E75]">
         </div>
       </div>
+      {% if specialty_options or category_options %}
+      <div class="grid sm:grid-cols-2 gap-4">
+        {% if specialty_options %}
+        <div>
+          <span class="block text-sm font-semibold mb-2" style="color:#0A4E75">{% trans "Специалности" %}</span>
+          <div class="flex flex-wrap gap-2">
+            {% for item in specialty_options %}
+            <label class="inline-flex items-center gap-2 bg-white border border-gray-200 px-3 py-1 rounded-full text-sm text-[#0A4E75]">
+              <input type="checkbox" name="specialty" value="{{ item.id }}" class="rounded border-gray-300 text-[#0A4E75] focus:ring-[#0A4E75]">
+              <span>{{ item.name }}</span>
+            </label>
+            {% endfor %}
+          </div>
+        </div>
+        {% endif %}
+        {% if category_options %}
+        <div>
+          <span class="block text-sm font-semibold mb-2" style="color:#0A4E75">{% trans "Категории" %}</span>
+          <div class="flex flex-wrap gap-2">
+            {% for item in category_options %}
+            <label class="inline-flex items-center gap-2 bg-white border border-gray-200 px-3 py-1 rounded-full text-sm text-[#0A4E75]">
+              <input type="checkbox" name="category" value="{{ item.id }}" class="rounded border-gray-300 text-[#0A4E75] focus:ring-[#0A4E75]">
+              <span>{{ item.name }}</span>
+            </label>
+            {% endfor %}
+          </div>
+        </div>
+        {% endif %}
+      </div>
+      {% endif %}
+      {% if event_options %}
+      <div>
+        <label class="block text-sm font-semibold mb-1" style="color:#0A4E75">{% trans "Събития" %}</label>
+        <select name="event" multiple size="5" class="w-full rounded-lg border border-gray-300 bg-white text-[#0A4E75] p-2">
+          {% for item in event_options %}
+          <option value="{{ item.id }}">{{ item.label }}</option>
+          {% endfor %}
+        </select>
+        <p class="text-xs text-gray-500 mt-1">{% trans "Изберете едно или повече събития (задръжте Ctrl/Command за множество)." %}</p>
+      </div>
+      {% endif %}
+      {% if indicator_options %}
+      <div>
+        <span class="block text-sm font-semibold mb-2" style="color:#0A4E75">{% trans "Лабораторни показатели" %}</span>
+        <div class="flex flex-wrap gap-2">
+          {% for item in indicator_options %}
+          <label class="inline-flex items-center gap-2 bg-white border border-gray-200 px-3 py-1 rounded-full text-sm text-[#0A4E75]">
+            <input type="checkbox" name="indicator" value="{{ item.slug }}" class="rounded border-gray-300 text-[#0A4E75] focus:ring-[#0A4E75]">
+            <span>{{ item.name }}</span>
+          </label>
+          {% endfor %}
+        </div>
+      </div>
+      {% endif %}
       <div class="flex items-center gap-6 mt-2">
-        <label class="inline-flex items-center gap-2"><input id="generate-events" type="checkbox" class="w-4 h-4"><span>{% trans "PDF събития" %}</span></label>
-        <label class="inline-flex items-center gap-2"><input id="generate-labs" type="checkbox" class="w-4 h-4"><span>{% trans "PDF лаборатории" %}</span></label>
-        <label class="inline-flex items-center gap-2"><input id="generate-csv" type="checkbox" class="w-4 h-4"><span>CSV</span></label>
+        <label class="inline-flex items-center gap-2"><input id="generate-events" name="generate_events" type="checkbox" class="w-4 h-4" value="1" checked><span>{% trans "PDF събития" %}</span></label>
+        <label class="inline-flex items-center gap-2"><input id="generate-labs" name="generate_labs" type="checkbox" class="w-4 h-4" value="1" checked><span>{% trans "PDF лаборатории" %}</span></label>
+        <label class="inline-flex items-center gap-2"><input id="generate-csv" name="generate_csv" type="checkbox" class="w-4 h-4" value="1" checked><span>CSV</span></label>
       </div>
       <div class="mt-4">
-        <button type="button" id="gen-links" class="px-4 py-2 rounded-xl bg-primary text-blockalt opacity-50 cursor-not-allowed" aria-disabled="true">{% trans "Приложи филтри" %}</button>
+        <button type="button" id="gen-links" class="px-4 py-2 rounded-xl bg-primary text-blockalt">{% trans "Приложи филтри" %}</button>
       </div>
     </form>
   </section>

--- a/records/templates/subpages/labtestssubpages/labtest_edit.html
+++ b/records/templates/subpages/labtestssubpages/labtest_edit.html
@@ -1,64 +1,43 @@
 {% extends 'basetemplates/base_app.html' %}
-{% load static %}
 {% load i18n %}
 
 {% block app_content %}
-    {% block scripts %}
-        <script src="{% static 'js/labtest_edit_logic.js' %}"></script>
-    {% endblock %}
 <main class="bg-site-background min-h-screen p-4 md:p-8">
-    <div class="container mx-auto max-w-7xl">
-        <div class="bg-block-background p-6 rounded-3xl shadow-lg mb-8">
-            <h1 class="text-3xl font-bold text-gray-800">
-                {% trans "Редакция на кръвни показатели" %}
-            </h1>
-            <p class="mt-2 text-gray-600">
-                {% trans "Преглед и редактиране на стойностите на лабораторните показатели." %}
-            </p>
-        </div>
-
-        <div class="bg-block-background p-6 rounded-3xl shadow-lg">
-            <div class="bg-navbar-button-blue text-white p-4 rounded-t-3xl -mx-6 -mt-6 mb-4 flex justify-between items-center">
-                <h2 class="text-xl font-semibold">{% trans "Стойности на показателите" %}</h2>
-                <button class="px-6 py-3 bg-checkmark-green text-white font-bold rounded-lg shadow-md hover:bg-green-700 transition-colors">
-                    {% trans "ЗАПИШИ" %}
-                </button>
-            </div>
-
-            <div class="overflow-x-auto">
-                <div class="grid grid-cols-[auto_repeat(6,minmax(120px,1fr))] gap-1 min-w-max text-gray-700">
-                    <div class="bg-button-blue text-white py-2 px-3 rounded-tl-lg font-semibold"></div>
-                    {% for i in "xxxxxx" %}
-                        <div class="bg-button-blue text-white py-2 px-3 text-center font-semibold">1{{ i }}.06.2025</div>
-                    {% endfor %}
-
-                    <div class="bg-navbar-button-blue text-white py-2 px-3 font-semibold flex items-center justify-between">TSH</div>
-                    {% for i in "xxxxxx" %}
-                        <input type="text" class="bg-creamy-main-content border border-gray-300 p-2 text-center rounded-sm" value="1.12" />
-                    {% endfor %}
-
-                    <div class="bg-navbar-button-blue text-white py-2 px-3 font-semibold flex items-center justify-between">T4</div>
-                    {% for i in "xxxxxx" %}
-                        <input type="text" class="bg-creamy-main-content border border-gray-300 p-2 text-center rounded-sm" value="15.2" />
-                    {% endfor %}
-
-                    <div class="bg-navbar-button-blue text-white py-2 px-3 font-semibold flex items-center justify-between">{% trans "Хемоглобин" %}</div>
-                    {% for i in "xxxxxx" %}
-                        <input type="text" class="bg-creamy-main-content border border-gray-300 p-2 text-center rounded-sm" value="142" />
-                    {% endfor %}
-
-                    <div class="bg-navbar-button-blue text-white py-2 px-3 font-semibold flex items-center justify-between">{% trans "Триглицериди" %}</div>
-                    {% for i in "xxxxxx" %}
-                        <input type="text" class="bg-creamy-main-content border border-gray-300 p-2 text-center rounded-sm" value="1.78" />
-                    {% endfor %}
-
-                    <div class="bg-navbar-button-blue text-white py-2 px-3 font-semibold flex items-center justify-between">WBC</div>
-                    {% for i in "xxxxxx" %}
-                        <input type="text" class="bg-creamy-main-content border border-gray-300 p-2 text-center rounded-sm" value="6.6" />
-                    {% endfor %}
-                </div>
-            </div>
-        </div>
+  <div class="container mx-auto max-w-3xl space-y-6">
+    <div class="bg-block-background p-6 rounded-3xl shadow-lg">
+      <h1 class="text-3xl font-bold text-gray-800">{% trans "Добавяне на лабораторен резултат" %}</h1>
+      <p class="mt-2 text-gray-600 text-sm">
+        {% blocktrans with event_id=event.id %}Записът ще бъде добавен към събитие №{{ event_id }}.{% endblocktrans %}
+      </p>
     </div>
+
+    <div class="bg-block-background p-6 rounded-3xl shadow-lg">
+      <form method="post" class="space-y-6">
+        {% csrf_token %}
+        {{ form.non_field_errors }}
+        {% for field in form %}
+          <div>
+            <label class="block text-sm font-semibold text-gray-700" for="{{ field.id_for_label }}">{{ field.label }}</label>
+            {{ field.as_widget(attrs={"class": "mt-1 w-full rounded-lg border-gray-300 focus:ring-emerald-500 focus:border-emerald-500"}) }}
+            {% if field.help_text %}
+              <p class="mt-1 text-xs text-gray-500">{{ field.help_text }}</p>
+            {% endif %}
+            {% for error in field.errors %}
+              <p class="mt-1 text-xs text-red-600">{{ error }}</p>
+            {% endfor %}
+          </div>
+        {% endfor %}
+
+        <div class="flex items-center justify-between gap-3">
+          <a href="{% url 'medj:labtests_view' event.id %}" class="px-4 py-2 rounded-xl border border-gray-300 text-sm text-gray-700 hover:bg-gray-50">
+            {% trans "Назад" %}
+          </a>
+          <button type="submit" class="px-6 py-2 rounded-xl bg-emerald-600 text-white font-semibold shadow hover:bg-emerald-700 transition">
+            {% trans "Запази" %}
+          </button>
+        </div>
+      </form>
+    </div>
+  </div>
 </main>
 {% endblock %}

--- a/records/templates/subpages/labtestssubpages/labtests.html
+++ b/records/templates/subpages/labtestssubpages/labtests.html
@@ -1,95 +1,141 @@
 {% extends 'basetemplates/base_app.html' %}
-{% load static %}
 {% load i18n %}
 
 {% block app_content %}
 <main class="bg-site-background min-h-screen p-4 md:p-8">
-  <div class="container mx-auto max-w-7xl">
-    <div class="bg-block-background p-6 rounded-3xl shadow-lg mb-8">
+  <div class="container mx-auto max-w-7xl space-y-6">
+    <div class="bg-block-background p-6 rounded-3xl shadow-lg">
       <h1 class="text-3xl font-bold text-gray-800">{% trans "Лабораторни показатели" %}</h1>
-      <p class="mt-2 text-gray-600">{% trans "Визуализация на кръвни изследвания и други показатели." %}</p>
+      {% if medical_event %}
+        <p class="mt-2 text-sm text-gray-600">
+          {% trans "Събитие" %}: <span class="font-semibold text-gray-800">№{{ medical_event.id }}</span>
+          {% if medical_event.event_date %} · {{ medical_event.event_date|date:"d.m.Y" }}{% endif %}
+          {% if medical_event.summary %} · {{ medical_event.summary }}{% endif %}
+        </p>
+      {% else %}
+        <p class="mt-2 text-gray-600">{% trans "Преглед на всички запазени лабораторни резултати по събития." %}</p>
+      {% endif %}
     </div>
 
     <div class="grid grid-cols-1 lg:grid-cols-4 gap-6">
-      <div class="lg:col-span-1 bg-block-background p-6 rounded-3xl shadow-lg">
-        <div class="mb-6">
-          <button id="btnSave" class="w-full px-6 py-3 bg-checkmark-green text-white font-bold rounded-lg shadow-md hover:bg-green-700 transition-colors">
-            {% trans "ЗАПИШИ" %}
-          </button>
-        </div>
-
-        <form id="csvForm" method="get" action="{% url 'medj:export_lab_csv' %}" class="space-y-6">
-          {% if medical_event %}
-            <input type="hidden" name="event" value="{{ medical_event.id }}">
-          {% endif %}
-          <input type="hidden" name="codes" id="codesInput">
-
-          <div class="bg-button-blue text-white p-4 rounded-3xl">
-            <h3 class="text-lg font-semibold mb-3">{% trans "Филтър по дата" %}</h3>
-            <div class="space-y-3">
-              <div>
-                <label class="block text-sm mb-1">{% trans "От" %}</label>
-                <input type="date" name="from" class="w-full p-2 rounded-lg text-gray-900">
-              </div>
-              <div>
-                <label class="block text-sm mb-1">{% trans "До" %}</label>
-                <input type="date" name="to" class="w-full p-2 rounded-lg text-gray-900">
-              </div>
+      <aside class="lg:col-span-1 bg-block-background p-6 rounded-3xl shadow-lg space-y-6">
+        <form method="get" class="space-y-6">
+          <div>
+            <h2 class="text-lg font-semibold text-gray-800">{% trans "Филтър по дата" %}</h2>
+            <div class="mt-3 space-y-3">
+              <label class="block text-sm text-gray-600">
+                {% trans "От дата" %}
+                <input type="date" name="start_date" value="{{ start_date }}" class="mt-1 w-full rounded-lg border-gray-300 focus:ring-emerald-500 focus:border-emerald-500">
+              </label>
+              <label class="block text-sm text-gray-600">
+                {% trans "До дата" %}
+                <input type="date" name="end_date" value="{{ end_date }}" class="mt-1 w-full rounded-lg border-gray-300 focus:ring-emerald-500 focus:border-emerald-500">
+              </label>
             </div>
           </div>
 
           <div>
-            <h3 class="text-lg font-semibold text-gray-700 mb-3">{% trans "Показатели" %}</h3>
-            <div class="space-y-2">
-              <label class="flex items-center space-x-2 text-gray-700">
-                <input type="checkbox" class="form-checkbox indicator" data-code="TSH">
-                <span class="w-4 h-4 rounded-full bg-blue-500 flex-shrink-0"></span>
-                <span>TSH</span>
-              </label>
-              <label class="flex items-center space-x-2 text-gray-700">
-                <input type="checkbox" class="form-checkbox indicator" data-code="T4">
-                <span class="w-4 h-4 rounded-full bg-pink-500 flex-shrink-0"></span>
-                <span>T4</span>
-              </label>
-              <label class="flex items-center space-x-2 text-gray-700">
-                <input type="checkbox" class="form-checkbox indicator" data-code="MCHC">
-                <span class="w-4 h-4 rounded-full bg-yellow-500 flex-shrink-0"></span>
-                <span>MCHC</span>
-              </label>
-              <label class="flex items-center space-x-2 text-gray-700">
-                <input type="checkbox" class="form-checkbox indicator" data-code="INSULIN">
-                <span class="w-4 h-4 rounded-full bg-purple-600 flex-shrink-0"></span>
-                <span>{% trans "Инсулин" %}</span>
-              </label>
-            </div>
+            <h2 class="text-lg font-semibold text-gray-800">{% trans "Показатели" %}</h2>
+            {% if indicators %}
+              <ul class="mt-3 space-y-2 max-h-56 overflow-y-auto pr-1">
+                {% for indicator in indicators %}
+                  <li>
+                    <label class="flex items-center gap-2 text-sm text-gray-700">
+                      <input type="checkbox" name="indicator" value="{{ indicator.slug }}" {% if indicator.checked %}checked{% endif %} class="rounded border-gray-300 text-emerald-600 focus:ring-emerald-500">
+                      <span>{{ indicator.label }}</span>
+                    </label>
+                  </li>
+                {% endfor %}
+              </ul>
+            {% else %}
+              <p class="mt-2 text-sm text-gray-500">{% trans "Няма налични показатели." %}</p>
+            {% endif %}
           </div>
 
           <div class="space-y-3">
-            <button type="submit" id="btnCsv" class="w-full px-6 py-3 bg-button-blue text-white font-bold rounded-lg shadow-md hover:bg-navbar-button-blue transition-colors">
-              {% trans "Експорт CSV" %}
+            <button type="submit" class="w-full px-4 py-2 rounded-xl bg-emerald-600 text-white font-semibold shadow hover:bg-emerald-700 transition">
+              {% trans "Приложи филтрите" %}
             </button>
+            {% if has_filters %}
+              <a href="{% if medical_event %}{% url 'medj:labtests_view' medical_event.id %}{% else %}{% url 'medj:labtests' %}{% endif %}"
+                 class="block w-full px-4 py-2 text-center rounded-xl border border-gray-300 text-sm text-gray-700 hover:bg-gray-50">
+                {% trans "Изчисти" %}
+              </a>
+            {% endif %}
+            <a href="{{ csv_download_url }}" class="block w-full px-4 py-2 text-center rounded-xl bg-button-blue text-white font-semibold shadow hover:bg-navbar-button-blue transition">
+              {% trans "Изтегли като CSV" %}
+            </a>
           </div>
         </form>
-      </div>
+      </aside>
 
-      <div class="lg:col-span-3 bg-block-background p-6 rounded-3xl shadow-lg">
-        <div class="bg-navbar-button-blue text-white p-4 rounded-t-3xl -mx-6 -mt-6 mb-4">
-          <h2 class="text-xl font-semibold">{% trans "Графика на показателите" %}</h2>
+      <section class="lg:col-span-3 bg-block-background p-6 rounded-3xl shadow-lg">
+        <div class="flex items-center justify-between mb-4">
+          <h2 class="text-xl font-semibold text-gray-800">
+            {% if medical_event %}{% trans "Резултати от събитието" %}{% else %}{% trans "Всички резултати" %}{% endif %}
+          </h2>
+          <span class="text-sm text-gray-500">{% blocktrans count total=total_measurements %}{{ total }} запис{% plural %}{{ total }} записа{% endblocktrans %}</span>
         </div>
-        <div class="overflow-x-auto">
-          <div class="w-full h-96 bg-gray-100 rounded-lg shadow-inner flex items-center justify-center text-gray-500 text-center">
-            {% trans "Тук ще се появи интерактивна графика." %}
+
+        {% if measurements %}
+          <div class="overflow-x-auto">
+            <table class="min-w-full divide-y divide-gray-200 text-sm">
+              <thead class="bg-gray-50 text-gray-600 uppercase text-xs tracking-wide">
+                <tr>
+                  <th class="px-3 py-2 text-left">{% trans "Показател" %}</th>
+                  <th class="px-3 py-2 text-left">{% trans "Стойност" %}</th>
+                  <th class="px-3 py-2 text-left">{% trans "Единици" %}</th>
+                  <th class="px-3 py-2 text-left">{% trans "Референтен диапазон" %}</th>
+                  <th class="px-3 py-2 text-left">{% trans "Дата" %}</th>
+                  <th class="px-3 py-2 text-left">{% trans "Събитие" %}</th>
+                </tr>
+              </thead>
+              <tbody class="divide-y divide-gray-100">
+                {% for row in measurements %}
+                  <tr class="{% if row.abnormal_flag %}bg-red-50{% endif %}">
+                    <td class="px-3 py-2 font-medium text-gray-800">
+                      {{ row.indicator_name }}
+                    </td>
+                    <td class="px-3 py-2">
+                      <span class="font-semibold text-gray-900">{{ row.value }}</span>
+                      {% if row.abnormal_flag == 'H' %}
+                        <span class="text-xs text-red-600 ml-1">↑</span>
+                      {% elif row.abnormal_flag == 'L' %}
+                        <span class="text-xs text-red-600 ml-1">↓</span>
+                      {% endif %}
+                    </td>
+                    <td class="px-3 py-2 text-gray-600">{{ row.unit }}</td>
+                    <td class="px-3 py-2 text-gray-600">
+                      {% if row.reference_low or row.reference_high %}
+                        {{ row.reference_low|default:"—" }} – {{ row.reference_high|default:"—" }}
+                      {% else %}
+                        —
+                      {% endif %}
+                    </td>
+                    <td class="px-3 py-2 text-gray-600">
+                      {% if row.measured_at %}{{ row.measured_at|date:"d.m.Y H:i" }}{% else %}—{% endif %}
+                    </td>
+                    <td class="px-3 py-2 text-gray-600">
+                      {% if row.event %}
+                        <a href="{% url 'medj:labtests_view' row.event.id %}" class="text-emerald-700 hover:underline">
+                          №{{ row.event.id }}{% if row.event_summary %} · {{ row.event_summary }}{% endif %}
+                        </a>
+                      {% else %}
+                        —
+                      {% endif %}
+                    </td>
+                  </tr>
+                {% endfor %}
+              </tbody>
+            </table>
           </div>
-        </div>
-      </div>
+        {% else %}
+          <div class="flex flex-col items-center justify-center py-12 text-gray-500">
+            <p class="text-sm">{% trans "Няма записи за показване." %}</p>
+          </div>
+        {% endif %}
+      </section>
     </div>
   </div>
 </main>
-
-<script>
-document.getElementById('csvForm').addEventListener('submit', function(e){
-  const codes = Array.from(document.querySelectorAll('.indicator:checked')).map(i => i.getAttribute('data-code'));
-  document.getElementById('codesInput').value = codes.join(',');
-});
-</script>
 {% endblock %}

--- a/records/templates/subpages/labtestssubpages/labtests_export_csv.html
+++ b/records/templates/subpages/labtestssubpages/labtests_export_csv.html
@@ -1,102 +1,98 @@
-{% load i18n static %}
 {% extends "basetemplates/base_app.html" %}
+{% load i18n %}
 
-{% block title %}{% trans "Export Lab Tests (CSV)" %}{% endblock %}
+{% block app_content %}
+<main class="bg-site-background min-h-screen p-4 md:p-8">
+  <div class="max-w-4xl mx-auto space-y-6">
+    <div class="bg-block-background p-6 rounded-3xl shadow-lg flex items-center justify-between">
+      <h1 class="text-2xl font-semibold text-gray-800">{% trans "Експорт на лабораторни резултати" %}</h1>
+      <a href="{% url 'medj:labtests' %}" class="text-sm text-emerald-700 hover:underline">{% trans "Назад" %}</a>
+    </div>
 
-{% block content %}
-<div class="max-w-3xl mx-auto space-y-6">
-  <div class="flex items-center justify-between">
-    <h1 class="text-xl font-semibold">{% trans "Export Lab Tests (CSV)" %}</h1>
-    <a href="{% url 'medj:labtests' %}" class="text-sm underline opacity-80 hover:opacity-100">
-      {% trans "Back to Lab Tests" %}
-    </a>
+    <div class="bg-block-background p-6 rounded-3xl shadow-lg">
+      <form method="get" class="space-y-6">
+        <input type="hidden" name="download" value="1">
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <label class="block text-sm text-gray-700">
+            {% trans "От дата" %}
+            <input type="date" name="start_date" value="{{ start_date }}" class="mt-1 w-full rounded-xl border-gray-300 focus:ring-emerald-500 focus:border-emerald-500">
+          </label>
+          <label class="block text-sm text-gray-700">
+            {% trans "До дата" %}
+            <input type="date" name="end_date" value="{{ end_date }}" class="mt-1 w-full rounded-xl border-gray-300 focus:ring-emerald-500 focus:border-emerald-500">
+          </label>
+        </div>
+
+        <div>
+          <h2 class="text-sm font-semibold text-gray-700">{% trans "Показатели" %}</h2>
+          {% if indicators %}
+            <ul class="mt-3 grid grid-cols-1 sm:grid-cols-2 gap-2">
+              {% for indicator in indicators %}
+                <li>
+                  <label class="flex items-center gap-2 text-sm text-gray-700">
+                    <input type="checkbox" name="indicator" value="{{ indicator.slug }}" {% if indicator.checked %}checked{% endif %} class="rounded border-gray-300 text-emerald-600 focus:ring-emerald-500">
+                    <span>{{ indicator.label }}</span>
+                  </label>
+                </li>
+              {% endfor %}
+            </ul>
+          {% else %}
+            <p class="mt-2 text-sm text-gray-500">{% trans "Няма налични показатели за избор." %}</p>
+          {% endif %}
+        </div>
+
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <fieldset class="rounded-xl p-4 border border-gray-200">
+            <legend class="text-sm font-semibold text-gray-700 px-1">{% trans "Разделител на колоните" %}</legend>
+            <label class="flex items-center gap-2 mt-2 text-sm">
+              <input type="radio" name="separator" value="comma" {% if separator == 'comma' %}checked{% endif %} class="text-emerald-600 focus:ring-emerald-500">
+              {% trans "Запетая" %}
+            </label>
+            <label class="flex items-center gap-2 mt-2 text-sm">
+              <input type="radio" name="separator" value="semicolon" {% if separator == 'semicolon' %}checked{% endif %} class="text-emerald-600 focus:ring-emerald-500">
+              {% trans "Точка и запетая" %}
+            </label>
+            <label class="flex items-center gap-2 mt-2 text-sm">
+              <input type="radio" name="separator" value="tab" {% if separator == 'tab' %}checked{% endif %} class="text-emerald-600 focus:ring-emerald-500">
+              {% trans "Таб" %}
+            </label>
+          </fieldset>
+
+          <fieldset class="rounded-xl p-4 border border-gray-200">
+            <legend class="text-sm font-semibold text-gray-700 px-1">{% trans "Десетичен разделител" %}</legend>
+            <label class="flex items-center gap-2 mt-2 text-sm">
+              <input type="radio" name="decimal" value="." {% if decimal == '.' %}checked{% endif %} class="text-emerald-600 focus:ring-emerald-500">
+              .
+            </label>
+            <label class="flex items-center gap-2 mt-2 text-sm">
+              <input type="radio" name="decimal" value="," {% if decimal == ',' %}checked{% endif %} class="text-emerald-600 focus:ring-emerald-500">
+              ,
+            </label>
+          </fieldset>
+        </div>
+
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <label class="flex items-center gap-2 text-sm text-gray-700">
+            <input type="checkbox" name="header" value="1" {% if include_header %}checked{% endif %} class="rounded border-gray-300 text-emerald-600 focus:ring-emerald-500">
+            {% trans "Включи заглавен ред" %}
+          </label>
+          <label class="flex items-center gap-2 text-sm text-gray-700">
+            <input type="checkbox" name="only_abnormal" value="1" {% if only_abnormal %}checked{% endif %} class="rounded border-gray-300 text-emerald-600 focus:ring-emerald-500">
+            {% trans "Само стойности извън норма" %}
+          </label>
+        </div>
+
+        <div class="flex items-center justify-between text-sm text-gray-500">
+          <p>{% blocktrans count total=result_count %}{{ total }} запис ще бъде експортиран.{% plural %}{{ total }} записа ще бъдат експортирани.{% endblocktrans %}</p>
+          <a href="{% url 'medj:labtests' %}" class="text-emerald-700 hover:underline">{% trans "Виж всички" %}</a>
+        </div>
+
+        <div class="flex items-center gap-3">
+          <button type="submit" class="px-5 py-2 rounded-xl bg-emerald-600 text-white font-semibold shadow hover:bg-emerald-700 transition">{% trans "Експорт" %}</button>
+          <a href="{% url 'medj:labtests' %}" class="px-5 py-2 rounded-xl border border-gray-300 text-sm text-gray-700 hover:bg-gray-50">{% trans "Отказ" %}</a>
+        </div>
+      </form>
+    </div>
   </div>
-
-  <p class="text-sm opacity-80">
-    {% trans "Choose a date range and optional filters, then download your results as a CSV file." %}
-  </p>
-
-  <form method="get" action="{% url 'medj:export_lab_csv' %}" class="space-y-6">
-    <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
-      <label class="block">
-        <span class="block text-sm font-medium mb-1">{% trans "From date" %}</span>
-        <input type="date" name="start_date" class="w-full rounded-xl p-2 border" />
-      </label>
-
-      <label class="block">
-        <span class="block text-sm font-medium mb-1">{% trans "To date" %}</span>
-        <input type="date" name="end_date" class="w-full rounded-xl p-2 border" />
-      </label>
-    </div>
-
-    <div>
-      <span class="block text-sm font-medium mb-1">{% trans "Indicators" %}</span>
-      <select name="indicator" multiple size="6" class="w-full rounded-xl p-2 border">
-        {% if indicators %}
-          {% for ind in indicators %}
-            <option value="{{ ind.id }}">{{ ind.name }}</option>
-          {% endfor %}
-        {% else %}
-          <option disabled>{% trans "No indicators available" %}</option>
-        {% endif %}
-      </select>
-      <p class="text-xs mt-1 opacity-70">{% trans "Hold Ctrl/Cmd to select multiple indicators." %}</p>
-    </div>
-
-    <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
-      <fieldset class="rounded-xl p-3 border">
-        <legend class="text-sm font-medium px-1">{% trans "Column separator" %}</legend>
-        <label class="flex items-center gap-2 mt-1">
-          <input type="radio" name="sep" value="," checked />
-          <span class="text-sm">{% trans "Comma (,)" %}</span>
-        </label>
-        <label class="flex items-center gap-2 mt-1">
-          <input type="radio" name="sep" value=";" />
-          <span class="text-sm">{% trans "Semicolon (;)" %}</span>
-        </label>
-        <label class="flex items-center gap-2 mt-1">
-          <input type="radio" name="sep" value="\t" />
-          <span class="text-sm">{% trans "Tab" %}</span>
-        </label>
-      </fieldset>
-
-      <fieldset class="rounded-xl p-3 border">
-        <legend class="text-sm font-medium px-1">{% trans "Decimal separator" %}</legend>
-        <label class="flex items-center gap-2 mt-1">
-          <input type="radio" name="decimal" value="." checked />
-          <span class="text-sm">.</span>
-        </label>
-        <label class="flex items-center gap-2 mt-1">
-          <input type="radio" name="decimal" value="," />
-          <span class="text-sm">,</span>
-        </label>
-      </fieldset>
-    </div>
-
-    <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
-      <label class="flex items-center gap-2">
-        <input type="checkbox" name="header" value="1" checked />
-        <span class="text-sm">{% trans "Include header row" %}</span>
-      </label>
-
-      <label class="flex items-center gap-2">
-        <input type="checkbox" name="only_abnormal" value="1" />
-        <span class="text-sm">{% trans "Only abnormal results" %}</span>
-      </label>
-    </div>
-
-    <div class="flex items-center gap-3">
-      <button type="submit" class="px-4 py-2 rounded-xl bg-blue-600 text-white">
-        {% trans "Export CSV" %}
-      </button>
-      <a href="{% url 'medj:labtests' %}" class="px-4 py-2 rounded-xl border">
-        {% trans "Cancel" %}
-      </a>
-    </div>
-  </form>
-
-  <div class="text-xs opacity-70">
-    <p>{% trans "Tip: If your spreadsheet expects a different delimiter or decimal separator, adjust the options above before exporting." %}</p>
-  </div>
-</div>
+</main>
 {% endblock %}

--- a/records/tests/test_api_upload.py
+++ b/records/tests/test_api_upload.py
@@ -87,7 +87,11 @@ class UploadFlowTests(TestCase):
         self.assertTrue(data.get("ok"))
         self.assertTrue(MedicalEvent.objects.filter(id=data["event_id"]).exists())
         self.assertTrue(Document.objects.filter(id=data["document_id"]).exists())
-        self.assertTrue(LabTestMeasurement.objects.filter(medical_event_id=data["event_id"]).exists())
+        qs = LabTestMeasurement.objects.filter(medical_event_id=data["event_id"])
+        self.assertTrue(qs.exists())
+        measurement = qs.first()
+        self.assertAlmostEqual(measurement.value, 120.0)
+        self.assertEqual(measurement.measured_at.date().isoformat(), "2025-09-01")
 
     def test_events_suggest(self):
         ev = MedicalEvent.objects.create(patient=self.user.patientprofile, owner=self.user, category=self.cat, specialty=self.spc, doc_type=self.dtype, event_date="2025-09-01")

--- a/records/tests/test_share_and_export.py
+++ b/records/tests/test_share_and_export.py
@@ -1,7 +1,14 @@
 from django.test import TestCase, Client
 from django.contrib.auth.models import User
-import base64, json
-from records.models import MedicalCategory, MedicalSpecialty, DocumentType, MedicalEvent
+from django.urls import reverse
+import base64
+import json
+from records.models import (
+    MedicalCategory,
+    MedicalSpecialty,
+    DocumentType,
+    LabTestMeasurement,
+)
 
 class ShareExportTests(TestCase):
     def setUp(self):
@@ -11,6 +18,17 @@ class ShareExportTests(TestCase):
         self.cat = MedicalCategory.objects.create(slug="cat3")
         self.spc = MedicalSpecialty.objects.create(slug="spc3")
         self.dtype = DocumentType.objects.create(slug="type3")
+        for obj, name in (
+            (self.cat, "Категория"),
+            (self.spc, "Специалност"),
+            (self.dtype, "Тип документ"),
+        ):
+            try:
+                obj.set_current_language("bg")
+                obj.name = name
+                obj.save()
+            except Exception:
+                pass
 
     def _confirm_doc(self):
         b64 = base64.b64encode(b"x").decode("utf-8")
@@ -39,3 +57,44 @@ class ShareExportTests(TestCase):
         self.assertEqual(res.status_code, 200)
         body = res.content.decode("utf-8")
         self.assertIn("event_id,event_date,indicator_name,value,unit,reference_low,reference_high,measured_at,tags", body)
+
+    def test_share_filters_return_documents(self):
+        ids = self._confirm_doc()
+        ev_id = ids["event_id"]
+        measurement = LabTestMeasurement.objects.get(medical_event_id=ev_id)
+        payload = {
+            "start_date": "",
+            "end_date": "",
+            "hours_events": 12,
+            "hours_labs": 12,
+            "hours_csv": 12,
+            "generate_events": True,
+            "generate_labs": True,
+            "generate_csv": True,
+            "filters": {
+                "specialty": [str(self.spc.id)],
+                "category": [str(self.cat.id)],
+                "event": [str(ev_id)],
+                "indicator": [measurement.indicator.slug],
+            },
+        }
+        url = reverse("medj:create_download_links")
+        res = self.client.post(url, data=json.dumps(payload), content_type="application/json")
+        self.assertEqual(res.status_code, 200)
+        data = res.json()
+        self.assertGreaterEqual(data["counts"]["documents"], 1)
+        self.assertGreaterEqual(data["counts"]["events"], 1)
+        self.assertGreaterEqual(data["counts"]["labs"], 1)
+        self.assertTrue(data["pdf_events_url"])
+        self.assertTrue(data["pdf_labs_url"])
+        self.assertTrue(data["csv_url"])
+        doc_ids = {doc.get("id") for doc in data.get("documents", [])}
+        self.assertIn(ids["document_id"], doc_ids)
+
+        payload["filters"]["event"] = []
+        res2 = self.client.post(url, data=json.dumps(payload), content_type="application/json")
+        self.assertEqual(res2.status_code, 200)
+        data2 = res2.json()
+        doc_ids2 = {doc.get("id") for doc in data2.get("documents", [])}
+        self.assertIn(ids["document_id"], doc_ids2)
+        self.assertGreaterEqual(data2["counts"]["labs"], 1)

--- a/records/urls.py
+++ b/records/urls.py
@@ -29,9 +29,9 @@ from .views.documents import (
     document_detail,
     document_edit,
     document_edit_tags,
-    document_export_pdf,
     document_move,
 )
+from .views.exports import document_export_pdf
 from .views.events import event_list, event_detail, events_by_specialty, tags_autocomplete
 from .views.labs import labtests, labtests_view, labtest_edit, export_lab_csv
 from .views.pages import documents_view

--- a/records/views/documents.py
+++ b/records/views/documents.py
@@ -4,8 +4,6 @@ from django.contrib.auth.decorators import login_required
 from django.shortcuts import get_object_or_404, render, redirect
 from django.http import HttpRequest, HttpResponse, JsonResponse
 from django import forms
-from django.template.loader import render_to_string
-from django.utils.html import escape
 
 from ..models import Document, MedicalEvent
 from ..forms import DocumentEditForm, DocumentTagForm
@@ -66,25 +64,6 @@ def document_edit_tags(request: HttpRequest, pk: int) -> HttpResponse:
         form = DocumentTagForm(instance=doc)
     return render(request, "subpages/documentsubpages/document_edit_tags.html", {"form": form, "document": doc})
 
-
-@login_required
-def document_export_pdf(request: HttpRequest, pk: int) -> HttpResponse:
-    doc = get_object_or_404(
-        Document.objects.select_related("doc_type", "category", "medical_event"),
-        pk=pk,
-        owner=request.user,
-    )
-    body = doc.analysis_html or f"<pre>{escape((doc.analysis_text or doc.ocr_text or '').strip())}</pre>"
-    html = render_to_string("subpages/documentsubpages/document_pdf.html", {"document": doc, "html": body})
-    try:
-        from weasyprint import HTML
-
-        pdf = HTML(string=html, base_url=request.build_absolute_uri("/")).write_pdf()
-        response = HttpResponse(pdf, content_type="application/pdf")
-        response["Content-Disposition"] = f'attachment; filename="document_{doc.pk}.pdf"'
-        return response
-    except Exception:
-        return HttpResponse(html, content_type="text/html")
 
 @login_required
 def document_move(request: HttpRequest, pk: int) -> HttpResponse:

--- a/records/views/labs.py
+++ b/records/views/labs.py
@@ -2,66 +2,145 @@ from __future__ import annotations
 
 import csv
 from io import StringIO
+from urllib.parse import urlencode
 
 from django.contrib import messages
 from django.contrib.auth.decorators import login_required
 from django.http import HttpRequest, HttpResponse
 from django.shortcuts import get_object_or_404, render, redirect
+from django.urls import reverse
 
 from ..forms import LabTestMeasurementForm
 from ..models import LabIndicator, LabTestMeasurement, MedicalEvent
 from .utils import parse_date, require_patient_profile
 
 
+def _indicator_label(indicator: LabIndicator) -> str:
+    getter = getattr(indicator, "safe_translation_getter", None)
+    if callable(getter):
+        try:
+            label = getter("name", any_language=True)
+            if label:
+                return str(label)
+        except Exception:
+            pass
+    return (getattr(indicator, "name", None) or indicator.slug or "").strip()
+
+
+def _indicator_queryset(patient, event=None):
+    qs = LabIndicator.objects.filter(measurements__medical_event__patient=patient)
+    if event is not None:
+        qs = qs.filter(measurements__medical_event=event)
+    qs = qs.prefetch_related("translations").distinct()
+    return qs.order_by("translations__name", "slug")
+
+
+def _parse_filter_params(request: HttpRequest):
+    selected = [slug for slug in request.GET.getlist("indicator") if str(slug).strip()]
+    start_raw = (request.GET.get("start_date") or "").strip()
+    end_raw = (request.GET.get("end_date") or "").strip()
+    start_dt = parse_date(start_raw) if start_raw else None
+    end_dt = parse_date(end_raw) if end_raw else None
+    return selected, start_raw, end_raw, start_dt, end_dt
+
+
+def _coerce_bool(value, default=False):
+    if value in (None, ""):
+        return default
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)):
+        return bool(value)
+    return str(value).strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _build_measurement_rows(qs):
+    rows = []
+    for measurement in qs:
+        indicator = measurement.indicator
+        event = measurement.medical_event
+        rows.append(
+            {
+                "object": measurement,
+                "indicator_name": _indicator_label(indicator),
+                "indicator_slug": indicator.slug,
+                "value": measurement.value,
+                "unit": indicator.unit or "",
+                "measured_at": measurement.measured_at,
+                "event": event,
+                "event_summary": getattr(event, "summary", ""),
+                "event_date": getattr(event, "event_date", None),
+                "abnormal_flag": measurement.abnormal_flag,
+                "reference_low": indicator.reference_low,
+                "reference_high": indicator.reference_high,
+            }
+        )
+    return rows
+
+
+def _labtests_context(request: HttpRequest, patient, base_qs, event=None):
+    selected, start_raw, end_raw, start_dt, end_dt = _parse_filter_params(request)
+    qs = base_qs
+    if selected:
+        qs = qs.filter(indicator__slug__in=selected)
+    if start_dt:
+        qs = qs.filter(measured_at__date__gte=start_dt)
+    if end_dt:
+        qs = qs.filter(measured_at__date__lte=end_dt)
+    qs = qs.select_related("indicator", "medical_event").order_by("-measured_at", "-id")
+    measurements = list(qs)
+    indicator_qs = _indicator_queryset(patient, event)
+    indicator_options = [
+        {
+            "slug": ind.slug,
+            "label": _indicator_label(ind),
+            "checked": ind.slug in selected,
+        }
+        for ind in indicator_qs
+    ]
+    indicator_options.sort(key=lambda x: x["label"].lower())
+
+    csv_params = []
+    for slug in selected:
+        csv_params.append(("indicator", slug))
+    if start_raw:
+        csv_params.append(("start_date", start_raw))
+    if end_raw:
+        csv_params.append(("end_date", end_raw))
+    if event:
+        csv_params.append(("event", str(event.id)))
+    csv_params.append(("download", "1"))
+    csv_url = reverse("medj:export_lab_csv")
+    csv_download_url = f"{csv_url}?{urlencode(csv_params, doseq=True)}"
+
+    return {
+        "medical_event": event,
+        "measurements": _build_measurement_rows(measurements),
+        "indicators": indicator_options,
+        "selected_indicators": set(selected),
+        "start_date": start_raw,
+        "end_date": end_raw,
+        "csv_download_url": csv_download_url,
+        "has_filters": bool(selected or start_raw or end_raw),
+        "total_measurements": len(measurements),
+    }
+
+
 @login_required
 def labtests(request: HttpRequest) -> HttpResponse:
-    require_patient_profile(request.user)
-    indicators = (
-        LabIndicator.objects.filter(is_active=True)
-        .prefetch_related("translations")
-        .order_by("translations__name", "id")
-    )
-    return render(
-        request,
-        "subpages/labtestssubpages/labtests.html",
-        {"indicators": indicators, "medical_event": None},
-    )
+    patient = require_patient_profile(request.user)
+    base_qs = LabTestMeasurement.objects.filter(medical_event__patient=patient)
+    context = _labtests_context(request, patient, base_qs, event=None)
+    return render(request, "subpages/labtestssubpages/labtests.html", context)
 
 
 @login_required
 def labtests_view(request: HttpRequest, event_id: int | str) -> HttpResponse:
     patient = require_patient_profile(request.user)
     event = get_object_or_404(MedicalEvent, pk=event_id, patient=patient)
-
-    indicators = (
-        LabIndicator.objects.filter(is_active=True)
-        .prefetch_related("translations")
-        .order_by("translations__name", "id")
-    )
-    series: dict[str, list[dict]] = {}
-
-    qs = (
-        LabTestMeasurement.objects.filter(medical_event=event)
-        .select_related("indicator")
-        .order_by("indicator__name", "measured_at")
-    )
-    for m in qs:
-        name = m.indicator.safe_translation_getter("name", any_language=True) or m.indicator.slug
-        key = name
-        series.setdefault(key, []).append(
-            {
-                "date": m.measured_at.isoformat() if m.measured_at else "",
-                "value": float(m.value),
-                "unit": m.indicator.unit or "",
-                "abn": m.is_abnormal,
-            }
-        )
-
-    return render(
-        request,
-        "subpages/labtestssubpages/labtests.html",
-        {"medical_event": event, "series": series, "indicators": indicators},
-    )
+    base_qs = LabTestMeasurement.objects.filter(medical_event=event)
+    context = _labtests_context(request, patient, base_qs, event=event)
+    return render(request, "subpages/labtestssubpages/labtests.html", context)
 
 
 @login_required
@@ -86,41 +165,119 @@ def labtest_edit(request: HttpRequest, event_id: int | str) -> HttpResponse:
 @login_required
 def export_lab_csv(request: HttpRequest) -> HttpResponse:
     patient = require_patient_profile(request.user)
-    event_id = request.GET.get("event")
-    codes_raw = (request.GET.get("codes") or "").strip()
-    from_raw = (request.GET.get("from") or "").strip()
-    to_raw = (request.GET.get("to") or "").strip()
+    download = _coerce_bool(request.GET.get("download"), default=False)
+    selected, start_raw, end_raw, start_dt, end_dt = _parse_filter_params(request)
+    event_raw = request.GET.get("event")
+    base_qs = LabTestMeasurement.objects.filter(medical_event__patient=patient)
+    event_obj = None
+    if event_raw and str(event_raw).isdigit():
+        event_id = int(event_raw)
+        base_qs = base_qs.filter(medical_event_id=event_id)
+        event_obj = MedicalEvent.objects.filter(pk=event_id, patient=patient).first()
 
-    indicator_slugs = [slug.strip() for slug in codes_raw.split(",") if slug.strip()]
-    date_from = parse_date(from_raw) if from_raw else None
-    date_to = parse_date(to_raw) if to_raw else None
+    qs = base_qs
+    if selected:
+        qs = qs.filter(indicator__slug__in=selected)
+    if start_dt:
+        qs = qs.filter(measured_at__date__gte=start_dt)
+    if end_dt:
+        qs = qs.filter(measured_at__date__lte=end_dt)
+    qs = qs.select_related("indicator", "medical_event").order_by("measured_at", "id")
+    measurements = list(qs)
 
-    measurements = LabTestMeasurement.objects.filter(medical_event__patient=patient).select_related("indicator", "medical_event")
-    if event_id and str(event_id).isdigit():
-        measurements = measurements.filter(medical_event_id=int(event_id))
-    if indicator_slugs:
-        measurements = measurements.filter(indicator__slug__in=indicator_slugs)
-    if date_from:
-        measurements = measurements.filter(measured_at__date__gte=date_from)
-    if date_to:
-        measurements = measurements.filter(measured_at__date__lte=date_to)
+    only_abnormal = _coerce_bool(request.GET.get("only_abnormal"), default=False)
+    if only_abnormal:
+        measurements = [m for m in measurements if m.abnormal_flag]
 
-    buffer = StringIO()
-    writer = csv.writer(buffer)
-    writer.writerow(["event_id", "event_date", "indicator", "value", "unit", "measured_at"])
-    for item in measurements.order_by("measured_at", "id"):
-        indicator_name = item.indicator.safe_translation_getter("name", any_language=True) or item.indicator.slug
-        measured_at = item.measured_at.isoformat() if item.measured_at else ""
-        event_date = item.medical_event.event_date.isoformat() if item.medical_event and item.medical_event.event_date else ""
-        writer.writerow([
-            item.medical_event_id,
-            event_date,
-            indicator_name,
-            item.value,
-            item.indicator.unit or "",
-            measured_at,
-        ])
+    separator_choice = (request.GET.get("separator") or "comma").lower()
+    if separator_choice in {";", "semicolon"}:
+        delimiter = ";"
+        separator_choice = "semicolon"
+    elif separator_choice in {"\\t", "tab"}:
+        delimiter = "\t"
+        separator_choice = "tab"
+    else:
+        delimiter = ","
+        separator_choice = "comma"
 
-    resp = HttpResponse(buffer.getvalue(), content_type="text/csv; charset=utf-8")
-    resp["Content-Disposition"] = 'attachment; filename="lab-results.csv"'
-    return resp
+    decimal_choice_raw = (request.GET.get("decimal") or ".").strip()
+    if decimal_choice_raw in {",", "comma"}:
+        decimal_char = ","
+        decimal_choice = ","
+    else:
+        decimal_char = "."
+        decimal_choice = "."
+
+    include_header = _coerce_bool(request.GET.get("header"), default=True)
+
+    def format_decimal(value):
+        if value in (None, ""):
+            return ""
+        if isinstance(value, (int, float)):
+            text = f"{value:.6f}".rstrip("0").rstrip(".")
+        else:
+            text = str(value)
+        if decimal_char != ".":
+            text = text.replace(".", decimal_char)
+        return text
+
+    if download:
+        buffer = StringIO()
+        writer = csv.writer(buffer, delimiter=delimiter)
+        if include_header:
+            writer.writerow([
+                "event_id",
+                "event_date",
+                "indicator_slug",
+                "indicator_name",
+                "value",
+                "unit",
+                "reference_low",
+                "reference_high",
+                "measured_at",
+                "abnormal_flag",
+            ])
+        for item in measurements:
+            indicator = item.indicator
+            event = item.medical_event
+            indicator_name = _indicator_label(indicator)
+            measured_at = item.measured_at.isoformat() if item.measured_at else ""
+            event_date = event.event_date.isoformat() if event and event.event_date else ""
+            writer.writerow([
+                item.medical_event_id,
+                event_date,
+                indicator.slug,
+                indicator_name,
+                format_decimal(item.value),
+                indicator.unit or "",
+                format_decimal(indicator.reference_low),
+                format_decimal(indicator.reference_high),
+                measured_at,
+                item.abnormal_flag,
+            ])
+        resp = HttpResponse(buffer.getvalue(), content_type="text/csv; charset=utf-8")
+        resp["Content-Disposition"] = 'attachment; filename="lab-results.csv"'
+        return resp
+
+    indicator_options = [
+        {
+            "slug": ind.slug,
+            "label": _indicator_label(ind),
+            "checked": ind.slug in selected,
+        }
+        for ind in _indicator_queryset(patient, event_obj)
+    ]
+    indicator_options.sort(key=lambda x: x["label"].lower())
+
+    context = {
+        "indicators": indicator_options,
+        "selected_indicators": set(selected),
+        "start_date": start_raw,
+        "end_date": end_raw,
+        "include_header": include_header,
+        "only_abnormal": only_abnormal,
+        "separator": separator_choice,
+        "decimal": decimal_choice,
+        "result_count": len(measurements),
+    }
+    return render(request, "subpages/labtestssubpages/labtests_export_csv.html", context)


### PR DESCRIPTION
## Summary
- populate the share page with specialty, category, event, and indicator filter metadata and widen `create_download_links` so indicator filters affect document, lab, and event results
- refresh the share template to expose the new filters, default the export toggles to checked, and keep the generator button enabled on first load
- extend the share/export test suite to cover filtered link generation alongside existing upload/export helpers

## Testing
- `pytest -q` *(fails: Django settings not configured in the current pytest environment)*
- `DJANGO_SETTINGS_MODULE=medj.settings.dev pytest -q` *(fails: Django apps not initialised under pytest without the Django plugin)*
- `python manage.py test records.tests.test_share_and_export --settings=medj.settings.dev` *(fails: PostgreSQL service "db" is unavailable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cca8689d508326b5cdb7339488d9e8