### PR TITLE
Allow admin URL to bypass onboarding redirect

### DIFF
--- a/records/management/middleware/onboarding.py
+++ b/records/management/middleware/onboarding.py
@@ -7,6 +7,7 @@ ALLOWED_PREFIXES = (
     "/favicon.ico/",
     "/robots.txt",
     "/i18n/",
+    "/admin/",
 )
 
 class OnboardingMiddleware(MiddlewareMixin):


### PR DESCRIPTION
## Summary
- allow admin requests to bypass the onboarding middleware redirect so the default Django admin remains accessible

## Testing
- python manage.py check

------
https://chatgpt.com/codex/tasks/task_e_68ccc19805f88326998a8e91df998859