### PR TITLE
Fix missing document PDF export template

### DIFF
--- a/records/templates/subpages/document_export_pdf.html
+++ b/records/templates/subpages/document_export_pdf.html
@@ -1,0 +1,1 @@
+{% include "subpages/documentsubpages/document_export_pdf.html" %}


### PR DESCRIPTION
## Summary
- add the expected document PDF export template path and reuse the existing implementation

## Testing
- python manage.py check

------
https://chatgpt.com/codex/tasks/task_e_68ccf3109c6c8326b8dafd5384b434d2